### PR TITLE
fix ci.yml by adding to Makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,5 @@ jobs:
       - name: Lint Python
         run: make lint
 
+      - name: Test
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -31,3 +31,7 @@ update-template-packages:  ## Update the project using the initial copier templa
 .PHONY: clean
 clean: ## Clean the temporary files.
 	rm -rf .ruff_cache
+
+.PHONY: test
+test:  ## Run the tests.
+	echo "Tests not implemented yet"


### PR DESCRIPTION
the problem is, when using the template with the template button, it replicates the whole repo, then it triggers github actions. Github actions don't have permissions to edit/add github actions. This is a fundamental feature to stop infinite loops and bad acting. This means that the original ci.yml and codeql.yml have to be identical when to the /project_template version as it cannot then edit those files. This means that if the user chooses pipenv, as the repo uses poetry, it will fail.

### What is the context of this PR?

Describe what you have changed and why, link to other PRs or Issues as appropriate.

### How to review

Describe the steps required to test the changes (include screenshots if appropriate).

### Follow-up Actions

List any follow-up actions (if applicable), like needed documentation updates or additional testing.
